### PR TITLE
Fix relative path bug.

### DIFF
--- a/openmedia/player/track.py
+++ b/openmedia/player/track.py
@@ -1,20 +1,20 @@
 from audiotools import open, Filename, UnsupportedFile
 import mutagen
-from math import ceil
+import os
 
 class Track(object):
 
     def __init__(self, file_path):
-        self.__file_path = file_path
+        self.__file_path = os.path.expanduser(file_path)
         try:
-            self.track_file = open(file_path)
+            self.track_file = open(self.__file_path)
             self.duration = float(self.track_file.seconds_length())
             self.metadata = self.track_file.get_metadata()
         except UnsupportedFile:
             if file_path.endswith(".mp3"):
                 from mutagen.mp3 import MP3, MPEGInfo
                 from mutagen import File
-                self.track_file = File(file_path)
+                self.track_file = File(self.__file_path)
                 self.metadata = Metadata(self.track_file)
                 self.duration = self.track_file.info.length
             else:

--- a/terminal_player.py
+++ b/terminal_player.py
@@ -13,10 +13,11 @@ def print_playlist(args):
         call(['clear'])
         print 'Type "h" for help.\nYour playlist is:'
         for arg in args:
-            if arg == os.path.basename(mixer.current_track.get_path()):
-                print '{:<8}{:}'.format('*', arg)
+            filename = os.path.basename(arg)
+            if filename  == os.path.basename(mixer.current_track.get_path()):
+                print '{:<8}{:}'.format('*', filename)
             else:
-                print '{:<8}{:}'.format('', arg)
+                print '{:<8}{:}'.format('', filename)
         if mixer.is_playing():
             print 'Playing'
         elif mixer.is_paused:


### PR DESCRIPTION
This branch contains a fix for the bug which caused an exception to be raised when adding tracks in `--no-gui` mode. Before this fix, supplying a relative path to the `a` option was not possible.
