### PR TITLE
Fix skipping

### DIFF
--- a/openmedia/gui/progressbar.py
+++ b/openmedia/gui/progressbar.py
@@ -24,8 +24,8 @@ class ProgressBar(Gtk.Scale):
         self._skipping = True
 
     def _end_skip(self, widget, value):
-        mixer.skip(widget.get_value())
         self._skipping = False
+        mixer.skip(widget.get_value())
 
 
 def _hms_format(scale, value):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -60,7 +60,7 @@ class TestPlayerFunctionality(unittest.TestCase):
     def test_get_song_index(self):
         for index, path in enumerate(self.track_paths):
             self.assertEqual(index,
-                             mixer.get_song_index(os.path.basename(path)))
+                             mixer.get_song_index(path))
 
     def test_set_volume(self):
         self.assertRaises(mixer.InvalidVolumeError,


### PR DESCRIPTION
This branch fixes a few problems with skipping:
* if the user 'skipped' before doing anything else, nothing would happen since the music used to only be loaded in the `play` method of mixer
* if the user 'skipped' when the mixer was in a 'paused' state, the icon of the play button would not get updated and the status bar would still read 'Paused.'