### PR TITLE
Path fix

### DIFF
--- a/openmedia/player/player.py
+++ b/openmedia/player/player.py
@@ -3,6 +3,7 @@ from .track import Track
 from .playerthread import PlayerThread
 from openmedia.observable.observable import Observable
 
+
 PLAY_EVENT, PAUSE_EVENT, STOP_EVENT,\
             NEXT_EVENT, SLIDER_EVENT = [index for index in range(5)]
 
@@ -34,7 +35,12 @@ class Player(Observable):
             Player._instance = self
 
         self._shuffle = False
-        self.track_list = [Track(song) for song in song_list]
+        self.track_list = []
+        for song in song_list:
+            try:
+                self.track_list.append(Track(song))
+            except:
+                print("Invalid file:", song)
         self.curr_track_index = -1
         self.speed = 1.0
         if len(self.track_list):

--- a/openmedia/player/track.py
+++ b/openmedia/player/track.py
@@ -1,3 +1,4 @@
+import os.path
 from gi.repository import Gst, GstPbutils
 
 
@@ -18,9 +19,9 @@ class Track(object):
         :param file_path: the path of the file out of which to create a track
         :type file_path: str
         """
-        self._file_path = file_path
+        self._file_path = os.path.abspath(file_path)
         self._metadata = {}
-        discoverer_info = self._get_discoverer_info(file_path)
+        discoverer_info = self._get_discoverer_info(self._file_path)
         tags = discoverer_info.get_tags()
         self._metadata['title'] = tags.get_string(Gst.TAG_TITLE)[1]
         self._duration = discoverer_info.get_duration() / Gst.SECOND


### PR DESCRIPTION
Fixes an error which did not allow tracks in the current working directory to be played. Now all paths are expanded and there is also a check for invalid file names.