### PR TITLE
Replace pipeline by playbin.

### DIFF
--- a/openmedia/player/playerthread.py
+++ b/openmedia/player/playerthread.py
@@ -22,7 +22,8 @@ class PlayerThread(Thread):
             player = Player.instance()
             pos = player.get_current_second()
             # XXX this condition should be improved
-            if player.is_playing() and abs(player.get_song_duration() - pos) <= 1:
+            if player.is_playing() and \
+                    abs(player.get_song_duration() - pos) <= 1:
                 player.play_next()
             else:
                 time.sleep(0.1)

--- a/openmedia/player/track.py
+++ b/openmedia/player/track.py
@@ -2,6 +2,9 @@ import os.path
 from gi.repository import Gst, GstPbutils
 
 
+DEFAULT_IMAGE_PATH = './openmedia/gui/res/img/no_image.png'
+
+
 class Track(object):
     """
     This holds data about media files.
@@ -30,7 +33,7 @@ class Track(object):
         if tags.get_sample(Gst.TAG_IMAGE)[0]:
             self._metadata['image'] = tags.get_sample(Gst.TAG_IMAGE)[1]
         else:
-            self._metadata['image'] = os.path.abspath('./openmedia/gui/res/img/no_image.png')
+            self._metadata['image'] = os.path.abspath(DEFAULT_IMAGE_PATH)
         self._duration = discoverer_info.get_duration() / Gst.SECOND
 
     def _get_discoverer_info(self, file_path):


### PR DESCRIPTION
This branch replaces the usage of the `Gstreamer pipeline` with the `playbin` element which is far superior and helps us integrate video playback more easily.

It also removes some code redundancy and breaks long lines.